### PR TITLE
Space-travelers: Switch badges for rockets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,3 +74,13 @@ a::after {
   color: #fff;
   cursor: pointer;
 }
+
+.reserved {
+  background-color: #68c1d0;
+  color: #fff;
+  margin-right: 5px;
+  border-radius: 5px;
+  padding: 4px;
+  width: 15%;
+  text-align: center;
+}

--- a/src/Components/rockets.js
+++ b/src/Components/rockets.js
@@ -29,6 +29,11 @@ const Rockets = () => {
           </div>
           <div className="rocket-details">
             <h1 className="name">{rocket.rocket_name}</h1>
+            {rocket.reserved ? (
+              <span className="reserved">Reserved</span>
+            ) : (
+              null
+            )}
             <p>{rocket.description}</p>
             {rocket.reserved && (
               <button


### PR DESCRIPTION
In this branch, I implemented the following;
>

- [x] Rockets that have already been reserved shows a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)
- [x] Used the React conditional rendering syntax:
- {rocket.reserved && ( 
    // render Cancel Rocket button
 )}